### PR TITLE
Testing adding return protection into SES_Wait function

### DIFF
--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -468,6 +468,7 @@ SES_Wait(struct sess *sp)
 	if (WS_Reserve(sp->ws, sizeof(struct waited))
 	    < sizeof(struct waited)) {
 		SES_Delete(sp, SC_OVERLOAD, NAN);
+		return;
 	}
 	wp = (void*)sp->ws->f;
 	INIT_OBJ(wp, WAITED_MAGIC);


### PR DESCRIPTION
Adding a return statement to avoid calling SES_Delete twice from single SES_Wait call. 